### PR TITLE
feat(p2p): add protocol handlers and session validation to test peer

### DIFF
--- a/test-peer/src/index.js
+++ b/test-peer/src/index.js
@@ -1,18 +1,21 @@
 /**
- * WhatNext Barebones Test Peer
+ * WhatNext Test Peer Client
  *
- * A minimal libp2p node for testing P2P connections with the WhatNext Electron app.
- * This peer uses the EXACT same configuration as the Electron app's utility process.
+ * A libp2p node that speaks both WhatNext protocols and maintains an in-memory
+ * session state. Designed for validating P2P playlist interactions and session
+ * participation during development.
  *
  * Usage:
  *   npm install
- *   npm start
+ *   npm start                     # Interactive CLI
+ *   PEER_NAME=Alice npm start     # Set display name
  *
  * Features:
  * - mDNS auto-discovery (finds Electron app on same network)
- * - WebRTC connections
- * - Connection logging
- * - Interactive CLI for testing
+ * - Handshake protocol: auto-initiates after connection, exchanges identity
+ * - RxDB replication: push/pull playlists, tracks, votes
+ * - In-memory session store with LWW conflict resolution
+ * - Interactive CLI for playlist interaction and session validation
  */
 
 import { createLibp2p } from 'libp2p';
@@ -26,94 +29,157 @@ import { identify } from '@libp2p/identify';
 import { circuitRelayTransport } from '@libp2p/circuit-relay-v2';
 import { FaultTolerance } from '@libp2p/interface';
 import { peerIdFromString } from '@libp2p/peer-id';
+import { randomUUID } from 'crypto';
 import chalk from 'chalk';
 import readline from 'readline';
+
 import { P2P_CONFIG } from './p2p-config.js';
+import {
+    registerHandshakeProtocol,
+    registerReplicationProtocol,
+    initiateHandshake,
+    pushDocuments,
+    pullCollection,
+    COLLECTIONS,
+} from './protocols.js';
+import {
+    applyDocuments,
+    getDocuments,
+    getCheckpoint,
+    setHandshakeInfo,
+    removeHandshakeInfo,
+    createTrackDocument,
+    createVoteDocument,
+    getTracksList,
+    formatPlaylistDisplay,
+    formatTracksDisplay,
+    formatPeersInfoDisplay,
+    formatSessionDisplay,
+    logChangeSummary,
+} from './session-store.js';
 
 // ========================================
-// Configuration (matches Electron app)
+// Identity
 // ========================================
 
 const PEER_NAME = process.env.PEER_NAME || `TestPeer-${Math.random().toString(36).substr(2, 6)}`;
+const LOCAL_USER_ID = randomUUID();
+
+/** Populated with peerId after node.start(). */
+const LOCAL_HANDSHAKE_DATA = {
+    displayName: PEER_NAME,
+    userId: LOCAL_USER_ID,
+    version: '0.1.0',
+    capabilities: ['replication', 'handshake'],
+    peerId: '',
+};
 
 // ========================================
-// libp2p Node
+// Node state
 // ========================================
 
 let node = null;
 let discoveredPeers = new Map(); // peerId -> { multiaddrs, timestamp }
-let connectedPeers = new Set();
+let connectedPeers = new Set();  // Set<peerId string>
+
+// Hoisted readline interface so protocol callbacks can call rl.prompt().
+const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+    prompt: chalk.cyan('whatnext> '),
+});
+
+// ========================================
+// Node startup
+// ========================================
 
 async function startNode() {
     console.log(chalk.cyan('\n🚀 Starting WhatNext Test Peer...\n'));
 
     try {
-        // IMPORTANT: This config matches app/src/utility/p2p-service.ts exactly
-        // All configuration is loaded from p2p-config.js (synced with app)
         node = await createLibp2p({
-            // Listen addresses - configured via P2P_CONFIG
             addresses: {
                 listen: P2P_CONFIG.LISTEN_ADDRESSES,
             },
-
-            // Allow node to start even if some transports fail to bind
             transportManager: {
                 faultTolerance: FaultTolerance.NO_FATAL,
             },
-
-            // Connection encryption
             connectionEncrypters: [noise()],
-
-            // Stream multiplexing
             streamMuxers: [yamux()],
-
-            // Transports (multiple for robustness)
             transports: [
-                tcp(),                      // Desktop-to-desktop, local testing
-                webSockets(),               // Web browser compatibility
-                webRTC(),                   // Browser-to-browser, WebRTC peers
-                circuitRelayTransport(),    // Required for WebRTC
+                tcp(),
+                webSockets(),
+                webRTC(),
+                circuitRelayTransport(),
             ],
-
-            // Peer discovery (mDNS for local network)
-            // CRITICAL: serviceName must match across all WhatNext peers
             peerDiscovery: [
                 mdns({
                     serviceName: P2P_CONFIG.MDNS_SERVICE_NAME,
                     interval: P2P_CONFIG.MDNS_INTERVAL,
                 }),
             ],
-
-            // Services
             services: {
                 identify: identify(),
             },
-
-            // Connection manager
             connectionManager: {
                 maxConnections: P2P_CONFIG.CONNECTION.MAX_CONNECTIONS,
             },
         });
 
-        // Setup event listeners
         setupEventListeners();
-
-        // Start the node
         await node.start();
+
+        // Now that we have a peerId, patch the handshake identity.
+        LOCAL_HANDSHAKE_DATA.peerId = node.peerId.toString();
+
+        // Register protocol handlers.
+        registerHandshakeProtocol(node, LOCAL_HANDSHAKE_DATA, (remotePeerId, data) => {
+            setHandshakeInfo(remotePeerId, data);
+            console.log(chalk.magenta(`\n[Handshake] ✅ Complete with ${data.displayName}`));
+            console.log(chalk.gray(`   Capabilities: ${(data.capabilities ?? []).join(', ')}\n`));
+            rl.prompt();
+        });
+
+        registerReplicationProtocol(
+            node,
+            // onPullRequest: serve local documents to peer
+            async (collection, checkpoint, limit) => {
+                return getDocuments(collection, checkpoint, limit);
+            },
+            // onPushReceived: apply incoming push and log changes
+            async (collection, documents) => {
+                const result = applyDocuments(collection, documents);
+                console.log(chalk.cyan(
+                    `\n[Replication] Push received: ${result.applied} applied, ${result.skipped} skipped (${collection})`,
+                ));
+                logChangeSummary(result.changes, collection);
+                rl.prompt();
+            },
+            // onPullResponse: apply pull results and log changes
+            (collection, documents, checkpoint) => {
+                const result = applyDocuments(collection, documents);
+                console.log(chalk.cyan(
+                    `\n[Replication] Pull complete: ${result.applied} applied, ${result.skipped} skipped (${collection})`,
+                ));
+                logChangeSummary(result.changes, collection);
+                rl.prompt();
+            },
+        );
 
         const peerId = node.peerId.toString();
         const multiaddrs = node.getMultiaddrs().map(ma => ma.toString());
 
         console.log(chalk.green('✅ Node started successfully!\n'));
-        console.log(chalk.bold('Your Peer ID:'));
+        console.log(chalk.bold('Identity:'));
+        console.log(chalk.gray(`  Name:    ${PEER_NAME}`));
+        console.log(chalk.gray(`  User ID: ${LOCAL_USER_ID}`));
+        console.log(chalk.bold('\nPeer ID:'));
         console.log(chalk.yellow(`  ${peerId}\n`));
         console.log(chalk.bold('Listening on:'));
         multiaddrs.forEach(addr => console.log(chalk.gray(`  ${addr}`)));
         console.log(chalk.gray('\n' + '─'.repeat(80) + '\n'));
-
         console.log(chalk.cyan('👂 Listening for mDNS peer discovery...'));
         console.log(chalk.gray('   (Make sure WhatNext Electron app is running on same network)\n'));
-
     } catch (error) {
         console.error(chalk.red('\n❌ Failed to start node:'), error);
         process.exit(1);
@@ -121,7 +187,7 @@ async function startNode() {
 }
 
 // ========================================
-// Event Listeners
+// Event listeners
 // ========================================
 
 function setupEventListeners() {
@@ -130,7 +196,6 @@ function setupEventListeners() {
         const peerId = evt.detail.id.toString();
         const multiaddrs = evt.detail.multiaddrs.map(ma => ma.toString());
 
-        // Store discovered peer
         discoveredPeers.set(peerId, {
             multiaddrs,
             timestamp: new Date().toISOString(),
@@ -142,40 +207,92 @@ function setupEventListeners() {
         console.log(chalk.gray(`   Type 'connect ${discoveredPeers.size}' to connect\n`));
     });
 
-    // Peer connected
-    node.addEventListener('peer:connect', (evt) => {
+    // Peer connected — auto-initiate handshake
+    node.addEventListener('peer:connect', async (evt) => {
         const peerId = evt.detail.toString();
         connectedPeers.add(peerId);
 
-        console.log(chalk.green.bold('\n✅ CONNECTED to peer!'));
+        console.log(chalk.green.bold('\n[P2P] ✅ Connected to peer!'));
         console.log(chalk.gray(`   Peer ID: ${peerId.slice(0, 20)}...`));
         console.log(chalk.gray(`   Total connections: ${connectedPeers.size}\n`));
+
+        // Small delay so the remote has time to register its protocol handler
+        // before we dial it. Both sides fire peer:connect simultaneously.
+        setTimeout(async () => {
+            try {
+                await initiateHandshake(node, peerId, LOCAL_HANDSHAKE_DATA);
+            } catch (err) {
+                console.log(chalk.yellow(`[Handshake] Failed to initiate: ${err.message}\n`));
+            }
+            rl.prompt();
+        }, 200);
     });
 
     // Peer disconnected
     node.addEventListener('peer:disconnect', (evt) => {
         const peerId = evt.detail.toString();
         connectedPeers.delete(peerId);
+        removeHandshakeInfo(peerId);
 
-        console.log(chalk.yellow('\n⚠️  Disconnected from peer'));
+        console.log(chalk.yellow('\n[P2P] ⚠️  Disconnected from peer'));
         console.log(chalk.gray(`   Peer ID: ${peerId.slice(0, 20)}...`));
         console.log(chalk.gray(`   Total connections: ${connectedPeers.size}\n`));
     });
 }
 
 // ========================================
-// CLI Commands
+// Peer resolution helper
+// ========================================
+
+/**
+ * Resolve a connected peer ID by 1-based index, or return the first connected peer.
+ * Returns null with an error message if no peers are connected or index is out of range.
+ *
+ * @param {string|undefined} indexArg - raw CLI argument, may be undefined
+ * @returns {string|null}
+ */
+function resolvePeer(indexArg) {
+    const peers = Array.from(connectedPeers);
+    if (peers.length === 0) {
+        console.log(chalk.red('\n❌ No connected peers. Use "connect <n>" first.\n'));
+        return null;
+    }
+    if (indexArg !== undefined) {
+        const idx = parseInt(indexArg, 10) - 1;
+        if (isNaN(idx) || idx < 0 || idx >= peers.length) {
+            console.log(chalk.red(`\n❌ Peer index ${indexArg} out of range (1–${peers.length})\n`));
+            return null;
+        }
+        return peers[idx];
+    }
+    return peers[0];
+}
+
+// ========================================
+// CLI commands
 // ========================================
 
 function showHelp() {
-    console.log(chalk.cyan('\n📖 Available Commands:\n'));
-    console.log(chalk.white('  list') + chalk.gray('           - List discovered peers'));
-    console.log(chalk.white('  connect <n>') + chalk.gray('    - Connect to peer number <n> from list'));
-    console.log(chalk.white('  connections') + chalk.gray('    - Show active connections'));
-    console.log(chalk.white('  status') + chalk.gray('         - Show node status'));
-    console.log(chalk.white('  help') + chalk.gray('           - Show this help'));
-    console.log(chalk.white('  exit') + chalk.gray('           - Stop the node and exit'));
-    console.log();
+    console.log(chalk.cyan('\n📖 Commands:\n'));
+    console.log(chalk.bold('  Connection'));
+    console.log(chalk.white('  list') + chalk.gray('                           List discovered peers'));
+    console.log(chalk.white('  connect <n>') + chalk.gray('                   Connect to discovered peer n'));
+    console.log(chalk.white('  connections') + chalk.gray('                   Show active connections'));
+    console.log(chalk.white('  status') + chalk.gray('                        Show node status'));
+    console.log('');
+    console.log(chalk.bold('  Session & Playlist'));
+    console.log(chalk.white('  pull [n]') + chalk.gray('                      Pull all collections from peer n (default: first connected)'));
+    console.log(chalk.white('  track-add [n] <title> [artist]') + chalk.gray(' Create a track locally and push to peer n'));
+    console.log(chalk.white('  playlist') + chalk.gray('                      Show current playlist state (tracks, mode, turn info)'));
+    console.log(chalk.white('  tracks') + chalk.gray('                        List all known tracks with 1-based indices'));
+    console.log(chalk.white('  peers-info') + chalk.gray('                    Show handshake info for connected peers'));
+    console.log(chalk.white('  vote [n] <trackIdx> <+1|-1>') + chalk.gray('  Send vote for a track to peer n'));
+    console.log(chalk.white('  session') + chalk.gray('                       Show full session state (collections, checkpoints)'));
+    console.log('');
+    console.log(chalk.bold('  General'));
+    console.log(chalk.white('  help') + chalk.gray('                          Show this help'));
+    console.log(chalk.white('  exit') + chalk.gray('                          Stop the node and exit'));
+    console.log('');
 }
 
 function listPeers() {
@@ -209,10 +326,12 @@ function showConnections() {
 
     let index = 1;
     for (const peerId of connectedPeers) {
-        console.log(chalk.green(`${index}. ${peerId.slice(0, 40)}...`));
+        const info = /** @type {any} */ (null); // getHandshakeInfo available if needed
+        const name = peerId; // display name via peers-info command
+        console.log(chalk.green(`${index}. ${peerId.slice(0, 52)}...`));
         index++;
     }
-    console.log();
+    console.log('');
 }
 
 function showStatus() {
@@ -220,18 +339,19 @@ function showStatus() {
     const multiaddrs = node.getMultiaddrs();
 
     console.log(chalk.cyan('\n📊 Node Status:\n'));
-    console.log(chalk.white('  Peer ID: ') + chalk.yellow(peerId));
-    console.log(chalk.white('  Multiaddrs: ') + chalk.gray(multiaddrs.length));
+    console.log(chalk.white('  Name:      ') + chalk.yellow(PEER_NAME));
+    console.log(chalk.white('  Peer ID:   ') + chalk.yellow(peerId));
+    console.log(chalk.white('  Multiaddrs:') + chalk.gray(` ${multiaddrs.length}`));
     multiaddrs.forEach(addr => {
         console.log(chalk.gray(`    ${addr.toString()}`));
     });
-    console.log(chalk.white('  Discovered Peers: ') + chalk.yellow(discoveredPeers.size));
-    console.log(chalk.white('  Active Connections: ') + chalk.green(connectedPeers.size));
-    console.log();
+    console.log(chalk.white('  Discovered Peers:  ') + chalk.yellow(discoveredPeers.size));
+    console.log(chalk.white('  Active Connections:') + chalk.green(` ${connectedPeers.size}`));
+    console.log('');
 }
 
 async function connectToPeer(peerNumber) {
-    const peerIndex = parseInt(peerNumber) - 1;
+    const peerIndex = parseInt(peerNumber, 10) - 1;
 
     if (isNaN(peerIndex) || peerIndex < 0) {
         console.log(chalk.red('\n❌ Invalid peer number. Use "list" to see available peers.\n'));
@@ -245,7 +365,7 @@ async function connectToPeer(peerNumber) {
         return;
     }
 
-    const [peerIdString, info] = peersArray[peerIndex];
+    const [peerIdString] = peersArray[peerIndex];
 
     if (connectedPeers.has(peerIdString)) {
         console.log(chalk.yellow('\n⚠️  Already connected to this peer\n'));
@@ -256,17 +376,14 @@ async function connectToPeer(peerNumber) {
     console.log(chalk.gray(`   Peer ID: ${peerIdString.slice(0, 40)}...\n`));
 
     try {
-        // Convert string peer ID to libp2p PeerId object
         const targetPeerId = peerIdFromString(peerIdString);
 
-        // Check if already connected
         const existingConns = node.getConnections(targetPeerId);
         if (existingConns.length > 0) {
             console.log(chalk.yellow('\n⚠️  Already connected to this peer (existing connection found)\n'));
             return;
         }
 
-        // Get peer from peerStore
         const peer = await node.peerStore.get(targetPeerId);
 
         if (!peer || peer.addresses.length === 0) {
@@ -276,12 +393,10 @@ async function connectToPeer(peerNumber) {
 
         console.log(chalk.gray(`   Trying ${peer.addresses.length} address(es)...\n`));
 
-        // Dial the peer
         const connection = await node.dial(targetPeerId);
 
-        console.log(chalk.green('✅ Connection initiated successfully!'));
+        console.log(chalk.green('✅ Connection initiated!'));
         console.log(chalk.gray(`   Remote address: ${connection.remoteAddr.toString()}\n`));
-
     } catch (error) {
         console.log(chalk.red('❌ Connection failed:'), error.message);
         console.log(chalk.gray('\nPossible reasons:'));
@@ -292,25 +407,149 @@ async function connectToPeer(peerNumber) {
     }
 }
 
+/**
+ * Pull all collections from a connected peer.
+ *
+ * @param {string|undefined} peerArg
+ */
+async function cmdPull(peerArg) {
+    const peerId = resolvePeer(peerArg);
+    if (!peerId) return;
+
+    console.log(chalk.cyan(`\n📥 Pulling all collections from ${peerId.slice(0, 16)}...\n`));
+
+    for (const collection of COLLECTIONS) {
+        try {
+            // Use stored checkpoint so subsequent pulls only fetch newer docs.
+            const checkpoint = getCheckpoint(collection);
+            await pullCollection(node, peerId, collection, checkpoint);
+        } catch (err) {
+            console.log(chalk.red(`  ❌ Failed to pull ${collection}: ${err.message}`));
+        }
+    }
+    console.log(chalk.gray('Pull requests sent. Responses arrive asynchronously.\n'));
+}
+
+/**
+ * Create a track document and push it to a connected peer.
+ *
+ * Argument forms:
+ *   track-add <title>
+ *   track-add <title> <artist>
+ *   track-add <peerIdx> <title>
+ *   track-add <peerIdx> <title> <artist>
+ *
+ * @param {string[]} args
+ */
+async function cmdTrackAdd(args) {
+    if (args.length === 0) {
+        console.log(chalk.red('\n❌ Usage: track-add [peerIdx] <title> [artist]\n'));
+        return;
+    }
+
+    let peerArg, title, artist;
+
+    // If the first arg is a plain integer, treat it as a peer index.
+    if (/^\d+$/.test(args[0])) {
+        peerArg = args[0];
+        title = args[1];
+        artist = args[2] ?? 'Unknown';
+    } else {
+        peerArg = undefined;
+        title = args[0];
+        artist = args[1] ?? 'Unknown';
+    }
+
+    if (!title) {
+        console.log(chalk.red('\n❌ Track title is required.\n'));
+        return;
+    }
+
+    const peerId = resolvePeer(peerArg);
+    if (!peerId) return;
+
+    const doc = createTrackDocument(title, artist, LOCAL_USER_ID);
+    applyDocuments('tracks', [doc]);
+
+    console.log(chalk.green(`\n🎵 Track created: "${title}" — ${artist}`));
+    console.log(chalk.gray(`   ID: ${doc.id}`));
+
+    try {
+        await pushDocuments(node, peerId, 'tracks', [doc]);
+        console.log(chalk.green('   ✅ Pushed to peer\n'));
+    } catch (err) {
+        console.log(chalk.red(`   ❌ Push failed: ${err.message}\n`));
+    }
+}
+
+/**
+ * Send a vote (+1 or -1) for a track to a connected peer.
+ *
+ * Argument forms:
+ *   vote <trackIdx> <value>
+ *   vote <peerIdx> <trackIdx> <value>
+ *
+ * @param {string[]} args
+ */
+async function cmdVote(args) {
+    if (args.length < 2) {
+        console.log(chalk.red('\n❌ Usage: vote [peerIdx] <trackIdx> <+1|-1>\n'));
+        return;
+    }
+
+    let peerArg, trackIdxStr, valueStr;
+
+    if (args.length >= 3 && /^\d+$/.test(args[0])) {
+        peerArg = args[0];
+        trackIdxStr = args[1];
+        valueStr = args[2];
+    } else {
+        peerArg = undefined;
+        trackIdxStr = args[0];
+        valueStr = args[1];
+    }
+
+    const peerId = resolvePeer(peerArg);
+    if (!peerId) return;
+
+    const trackIdx = parseInt(trackIdxStr, 10) - 1;
+    const tracks = getTracksList();
+
+    if (isNaN(trackIdx) || trackIdx < 0 || trackIdx >= tracks.length) {
+        console.log(chalk.red(`\n❌ Track index out of range. Use "tracks" to see available tracks (1–${tracks.length}).\n`));
+        return;
+    }
+
+    const value = valueStr === '+1' || valueStr === '1' ? 1 : -1;
+    const trackId = tracks[trackIdx].id;
+    const trackTitle = tracks[trackIdx].data?.title ?? trackId;
+
+    const doc = createVoteDocument(LOCAL_USER_ID, trackId, value);
+    applyDocuments('trackInteractions', [doc]);
+
+    console.log(chalk.yellow(`\n👍 Vote ${value > 0 ? '+1' : '-1'} for: ${trackTitle}`));
+
+    try {
+        await pushDocuments(node, peerId, 'trackInteractions', [doc]);
+        console.log(chalk.green('   ✅ Pushed to peer\n'));
+    } catch (err) {
+        console.log(chalk.red(`   ❌ Push failed: ${err.message}\n`));
+    }
+}
+
 // ========================================
 // CLI Interface
 // ========================================
 
 function startCLI() {
-    const rl = readline.createInterface({
-        input: process.stdin,
-        output: process.stdout,
-        prompt: chalk.cyan('whatnext> '),
-    });
-
     console.log(chalk.cyan('\n💬 Interactive CLI ready. Type "help" for commands.\n'));
     rl.prompt();
 
     rl.on('line', async (line) => {
         const input = line.trim();
-        const [command, ...args] = input.split(' ');
+        const [command, ...args] = input.split(/\s+/);
 
-        switch (command.toLowerCase()) {
+        switch ((command ?? '').toLowerCase()) {
             case 'help':
             case 'h':
                 showHelp();
@@ -340,6 +579,44 @@ function startCLI() {
                 showStatus();
                 break;
 
+            // ── Session & Playlist commands ──────────────────────────────────
+
+            case 'pull':
+                await cmdPull(args[0]);
+                break;
+
+            case 'track-add':
+            case 'ta':
+                await cmdTrackAdd(args);
+                break;
+
+            case 'playlist':
+            case 'pl':
+                console.log(formatPlaylistDisplay());
+                break;
+
+            case 'tracks':
+            case 'tr':
+                console.log(formatTracksDisplay());
+                break;
+
+            case 'peers-info':
+            case 'pi':
+                console.log(formatPeersInfoDisplay());
+                break;
+
+            case 'vote':
+            case 'v':
+                await cmdVote(args);
+                break;
+
+            case 'session':
+            case 'ss':
+                console.log(formatSessionDisplay());
+                break;
+
+            // ── General ─────────────────────────────────────────────────────
+
             case 'exit':
             case 'quit':
             case 'q':
@@ -349,7 +626,6 @@ function startCLI() {
                 break;
 
             case '':
-                // Empty line, do nothing
                 break;
 
             default:
@@ -374,31 +650,26 @@ function startCLI() {
 async function main() {
     console.clear();
     console.log(chalk.bold.cyan('╔════════════════════════════════════════════════════════════╗'));
-    console.log(chalk.bold.cyan('║          WhatNext Barebones Test Peer v1.0                ║'));
+    console.log(chalk.bold.cyan('║        WhatNext Test Peer Client v2.0                     ║'));
+    console.log(chalk.bold.cyan('║  Handshake · Replication · Playlist Validation            ║'));
     console.log(chalk.bold.cyan('╚════════════════════════════════════════════════════════════╝'));
 
     await startNode();
     startCLI();
 }
 
-// Handle graceful shutdown
 process.on('SIGINT', async () => {
     console.log(chalk.cyan('\n\n👋 Received SIGINT, shutting down gracefully...\n'));
-    if (node) {
-        await node.stop();
-    }
+    if (node) await node.stop();
     process.exit(0);
 });
 
 process.on('SIGTERM', async () => {
     console.log(chalk.cyan('\n\n👋 Received SIGTERM, shutting down gracefully...\n'));
-    if (node) {
-        await node.stop();
-    }
+    if (node) await node.stop();
     process.exit(0);
 });
 
-// Start the peer
 main().catch(error => {
     console.error(chalk.red('\n💥 Fatal error:'), error);
     process.exit(1);

--- a/test-peer/src/protocols.js
+++ b/test-peer/src/protocols.js
@@ -1,0 +1,226 @@
+/**
+ * WhatNext Protocol Implementations (JavaScript)
+ *
+ * JS ports of app/src/utility/protocols/handshake.ts
+ * and app/src/utility/protocols/replication.ts.
+ *
+ * Intentionally kept in sync with the TypeScript originals.
+ * One deliberate divergence: registerReplicationProtocol accepts an
+ * onPullResponse callback so the test peer can apply results that arrive
+ * asynchronously (the TS version handles this via IPC; we handle it inline).
+ */
+
+import { peerIdFromString } from '@libp2p/peer-id';
+import { P2P_CONFIG } from './p2p-config.js';
+
+// ─── Stream helpers ──────────────────────────────────────────────────────────
+
+/**
+ * Read all chunks from a libp2p stream source, concatenate, and JSON.parse.
+ *
+ * @template T
+ * @param {import('@libp2p/interface').Stream} stream
+ * @returns {Promise<T>}
+ */
+async function readStreamMessage(stream) {
+    const chunks = [];
+    for await (const chunk of stream.source) {
+        chunks.push(chunk.subarray());
+    }
+    const totalLength = chunks.reduce((acc, c) => acc + c.length, 0);
+    const combined = new Uint8Array(totalLength);
+    let offset = 0;
+    for (const chunk of chunks) {
+        combined.set(chunk, offset);
+        offset += chunk.length;
+    }
+    return JSON.parse(new TextDecoder().decode(combined));
+}
+
+/**
+ * JSON-stringify data and write to a stream.
+ *
+ * @param {import('@libp2p/interface').Stream} stream
+ * @param {unknown} data
+ * @returns {Promise<void>}
+ */
+async function writeStreamMessage(stream, data) {
+    const encoded = new TextEncoder().encode(JSON.stringify(data));
+    await stream.sink([encoded]);
+}
+
+// ─── Handshake Protocol ──────────────────────────────────────────────────────
+
+/**
+ * Register the responder side of /whatnext/handshake/1.0.0.
+ *
+ * Flow (mirrors handshake.ts):
+ *   1. Read remote peer's HandshakeData from the incoming stream.
+ *   2. Open a NEW stream on the same connection and write localData.
+ *   3. Fire onHandshake(remotePeerId, remoteData).
+ *
+ * @param {import('libp2p').Libp2p} node
+ * @param {object} localData - HandshakeData for this peer
+ * @param {(remotePeerId: string, data: object) => void} onHandshake
+ */
+export function registerHandshakeProtocol(node, localData, onHandshake) {
+    node.handle(P2P_CONFIG.PROTOCOLS.HANDSHAKE, async ({ stream, connection }) => {
+        try {
+            const remotePeerId = connection.remotePeer.toString();
+            console.log(`[Handshake] Incoming from ${remotePeerId.slice(0, 12)}...`);
+
+            const remoteData = await readStreamMessage(stream);
+
+            // Respond on a new stream (same pattern as TS original)
+            const responseStream = await connection.newStream(P2P_CONFIG.PROTOCOLS.HANDSHAKE);
+            await writeStreamMessage(responseStream, localData);
+
+            console.log(`[Handshake] Complete with ${remoteData.displayName}`);
+            onHandshake(remotePeerId, remoteData);
+        } catch (error) {
+            console.error('[Handshake] Error handling incoming:', error.message);
+        }
+    });
+}
+
+/**
+ * Initiator side: dial the handshake protocol and send localData.
+ * The response arrives via the registered handler above.
+ *
+ * @param {import('libp2p').Libp2p} node
+ * @param {string} remotePeerId
+ * @param {object} localData
+ * @returns {Promise<void>}
+ */
+export async function initiateHandshake(node, remotePeerId, localData) {
+    const peerId = peerIdFromString(remotePeerId);
+    console.log(`[Handshake] Initiating with ${remotePeerId.slice(0, 12)}...`);
+
+    const stream = await node.dialProtocol(peerId, P2P_CONFIG.PROTOCOLS.HANDSHAKE);
+    await writeStreamMessage(stream, localData);
+    // Response arrives asynchronously via the registered protocol handler.
+}
+
+// ─── Replication Protocol ────────────────────────────────────────────────────
+
+/**
+ * Register the /whatnext/rxdb-replication/1.0.0 handler.
+ *
+ * Handles all four message types. Key divergence from replication.ts:
+ * pull-response is forwarded to onPullResponse rather than silently ignored,
+ * because the test peer has no separate IPC layer to route it through.
+ *
+ * @param {import('libp2p').Libp2p} node
+ * @param {(collection: string, checkpoint: string|null, limit: number) =>
+ *          Promise<{documents: object[], checkpoint: string}>} onPullRequest
+ * @param {(collection: string, documents: object[]) => Promise<void>} onPushReceived
+ * @param {(collection: string, documents: object[], checkpoint: string) => void} onPullResponse
+ */
+export function registerReplicationProtocol(node, onPullRequest, onPushReceived, onPullResponse) {
+    node.handle(P2P_CONFIG.PROTOCOLS.RXDB_REPLICATION, async ({ stream, connection }) => {
+        try {
+            const message = await readStreamMessage(stream);
+            const remotePeer = connection.remotePeer.toString().slice(0, 12);
+
+            console.log(`[Replication] Received ${message.type} for ${message.collection} from ${remotePeer}...`);
+
+            switch (message.type) {
+                case 'pull-request': {
+                    const result = await onPullRequest(
+                        message.collection,
+                        message.checkpoint ?? null,
+                        message.limit ?? 100,
+                    );
+                    const responseStream = await connection.newStream(P2P_CONFIG.PROTOCOLS.RXDB_REPLICATION);
+                    await writeStreamMessage(responseStream, {
+                        type: 'pull-response',
+                        collection: message.collection,
+                        documents: result.documents,
+                        checkpoint: result.checkpoint,
+                    });
+                    break;
+                }
+
+                case 'push': {
+                    if (message.documents && message.documents.length > 0) {
+                        await onPushReceived(message.collection, message.documents);
+                    }
+                    const ackStream = await connection.newStream(P2P_CONFIG.PROTOCOLS.RXDB_REPLICATION);
+                    await writeStreamMessage(ackStream, {
+                        type: 'push-ack',
+                        collection: message.collection,
+                    });
+                    break;
+                }
+
+                case 'pull-response': {
+                    onPullResponse(
+                        message.collection,
+                        message.documents ?? [],
+                        message.checkpoint ?? null,
+                    );
+                    break;
+                }
+
+                case 'push-ack': {
+                    console.log(`[Replication] Push acknowledged for ${message.collection}`);
+                    break;
+                }
+
+                default:
+                    console.warn(`[Replication] Unknown message type: ${message.type}`);
+            }
+        } catch (error) {
+            console.error('[Replication] Error handling stream:', error.message);
+        }
+    });
+}
+
+/**
+ * Push documents for one collection to a remote peer.
+ *
+ * @param {import('libp2p').Libp2p} node
+ * @param {string} remotePeerId
+ * @param {string} collection
+ * @param {Array<{id: string, data: object, updatedAt: string, deleted?: boolean}>} documents
+ * @returns {Promise<void>}
+ */
+export async function pushDocuments(node, remotePeerId, collection, documents) {
+    const peerId = peerIdFromString(remotePeerId);
+    console.log(`[Replication] Pushing ${documents.length} doc(s) to ${remotePeerId.slice(0, 12)}... (${collection})`);
+    const stream = await node.dialProtocol(peerId, P2P_CONFIG.PROTOCOLS.RXDB_REPLICATION);
+    await writeStreamMessage(stream, {
+        type: 'push',
+        collection,
+        documents,
+    });
+}
+
+/**
+ * Send a pull-request for one collection to a remote peer.
+ * The response arrives asynchronously via the onPullResponse callback.
+ *
+ * @param {import('libp2p').Libp2p} node
+ * @param {string} remotePeerId
+ * @param {string} collection
+ * @param {string|null} checkpoint
+ * @param {number} [limit=100]
+ * @returns {Promise<void>}
+ */
+export async function pullCollection(node, remotePeerId, collection, checkpoint, limit = 100) {
+    const peerId = peerIdFromString(remotePeerId);
+    console.log(`[Replication] Pulling ${collection} from ${remotePeerId.slice(0, 12)}... (checkpoint: ${checkpoint ?? 'null'})`);
+    const stream = await node.dialProtocol(peerId, P2P_CONFIG.PROTOCOLS.RXDB_REPLICATION);
+    await writeStreamMessage(stream, {
+        type: 'pull-request',
+        collection,
+        checkpoint,
+        limit,
+    });
+}
+
+// ─── Re-exports ──────────────────────────────────────────────────────────────
+
+export { P2P_CONFIG };
+
+export const COLLECTIONS = ['playlists', 'tracks', 'trackInteractions', 'users'];

--- a/test-peer/src/session-store.js
+++ b/test-peer/src/session-store.js
@@ -1,0 +1,467 @@
+/**
+ * WhatNext Test Peer — In-Memory Session Store
+ *
+ * Maintains all replicated documents in memory with LWW conflict resolution.
+ * Document shapes match app/src/renderer/db/schemas.ts.
+ *
+ * ISO 8601 UTC string comparison is used for LWW because UTC timestamps
+ * sort lexicographically in the same order as chronologically.
+ */
+
+import { randomUUID } from 'crypto';
+import chalk from 'chalk';
+
+// ─── Collections ─────────────────────────────────────────────────────────────
+
+/**
+ * One Map<id, {id, data, updatedAt, deleted?}> per collection.
+ * @type {Record<string, Map<string, object>>}
+ */
+const collections = {
+    playlists: new Map(),
+    tracks: new Map(),
+    trackInteractions: new Map(),
+    users: new Map(),
+};
+
+/**
+ * Per-collection checkpoint: ISO timestamp of the newest accepted doc.
+ * Sent in pull-request messages so the remote only returns newer documents.
+ * @type {Map<string, string|null>}
+ */
+const checkpoints = new Map([
+    ['playlists', null],
+    ['tracks', null],
+    ['trackInteractions', null],
+    ['users', null],
+]);
+
+/**
+ * Handshake info keyed by peerId.
+ * @type {Map<string, object>}
+ */
+const handshakeInfoByPeer = new Map();
+
+// ─── LWW merge ───────────────────────────────────────────────────────────────
+
+/**
+ * Apply LWW for a single document. Incoming wins if there is no existing doc
+ * or incoming.updatedAt is strictly newer.
+ *
+ * @param {Map} collectionMap
+ * @param {{id: string, data: object, updatedAt: string, deleted?: boolean}} incoming
+ * @returns {{ applied: boolean, previous: object|null }}
+ */
+function applyLWW(collectionMap, incoming) {
+    const existing = collectionMap.get(incoming.id);
+    if (!existing || incoming.updatedAt > existing.updatedAt) {
+        collectionMap.set(incoming.id, incoming);
+        return { applied: true, previous: existing ?? null };
+    }
+    return { applied: false, previous: existing };
+}
+
+// ─── Core API ────────────────────────────────────────────────────────────────
+
+/**
+ * Apply an array of replication documents to a named collection.
+ * Runs LWW on each. Returns a change summary used by logChangeSummary.
+ *
+ * @param {string} collection
+ * @param {Array<{id: string, data: object, updatedAt: string, deleted?: boolean}>} documents
+ * @returns {{ applied: number, skipped: number, deleted: number, changes: Array }}
+ */
+export function applyDocuments(collection, documents) {
+    const map = collections[collection];
+    if (!map) {
+        console.warn(`[Store] Unknown collection: ${collection}`);
+        return { applied: 0, skipped: 0, deleted: 0, changes: [] };
+    }
+
+    let applied = 0;
+    let skipped = 0;
+    let deleted = 0;
+    const changes = [];
+
+    for (const doc of documents) {
+        const { applied: wasApplied, previous } = applyLWW(map, doc);
+        if (wasApplied) {
+            applied++;
+            if (doc.deleted) deleted++;
+            changes.push({
+                id: doc.id,
+                type: doc.deleted ? 'delete' : 'upsert',
+                previous,
+                incoming: doc,
+            });
+        } else {
+            skipped++;
+            changes.push({ id: doc.id, type: 'skipped', previous, incoming: doc });
+        }
+    }
+
+    // Update checkpoint to the max updatedAt among accepted documents.
+    const accepted = documents.filter((_, i) => changes[i]?.type !== 'skipped');
+    if (accepted.length > 0) {
+        const maxTs = accepted.reduce((max, d) => (d.updatedAt > max ? d.updatedAt : max), '');
+        const current = checkpoints.get(collection) ?? '';
+        if (maxTs > current) {
+            checkpoints.set(collection, maxTs);
+        }
+    }
+
+    return { applied, skipped, deleted, changes };
+}
+
+/**
+ * Retrieve all live (non-deleted) documents for a collection as replication
+ * envelopes. Filters to docs newer than checkpoint (null = return all).
+ *
+ * @param {string} collection
+ * @param {string|null} checkpoint
+ * @param {number} [limit=100]
+ * @returns {{ documents: object[], checkpoint: string }}
+ */
+export function getDocuments(collection, checkpoint, limit = 100) {
+    const map = collections[collection];
+    if (!map) return { documents: [], checkpoint: checkpoint ?? '' };
+
+    let docs = Array.from(map.values());
+    if (checkpoint) {
+        docs = docs.filter(d => d.updatedAt > checkpoint);
+    }
+    docs.sort((a, b) => a.updatedAt.localeCompare(b.updatedAt));
+    docs = docs.slice(0, limit);
+
+    const newCheckpoint =
+        docs.length > 0
+            ? docs[docs.length - 1].updatedAt
+            : (checkpoints.get(collection) ?? '');
+
+    return { documents: docs, checkpoint: newCheckpoint };
+}
+
+// ─── Handshake info ──────────────────────────────────────────────────────────
+
+export function setHandshakeInfo(peerId, data) {
+    handshakeInfoByPeer.set(peerId, data);
+}
+
+export function getHandshakeInfo(peerId) {
+    return handshakeInfoByPeer.get(peerId);
+}
+
+export function removeHandshakeInfo(peerId) {
+    handshakeInfoByPeer.delete(peerId);
+}
+
+// ─── Document factories ──────────────────────────────────────────────────────
+
+/**
+ * Create a track document envelope ready for replication.
+ * Matches TrackDocType from schemas.ts.
+ *
+ * @param {string} title
+ * @param {string} artist
+ * @param {string} addedBy - local user ID
+ * @returns {{id: string, data: object, updatedAt: string}}
+ */
+export function createTrackDocument(title, artist, addedBy) {
+    const id = randomUUID();
+    const now = new Date().toISOString();
+    return {
+        id,
+        data: {
+            id,
+            title,
+            artists: [artist],
+            album: 'Unknown',
+            durationMs: 0,
+            addedAt: now,
+            addedBy,
+        },
+        updatedAt: now,
+    };
+}
+
+/**
+ * Create a trackInteraction vote document envelope.
+ * id is composite: `${userId}_${trackId}_vote`.
+ *
+ * @param {string} userId
+ * @param {string} trackId
+ * @param {number} value - +1 or -1
+ * @returns {{id: string, data: object, updatedAt: string}}
+ */
+export function createVoteDocument(userId, trackId, value) {
+    const id = `${userId}_${trackId}_vote`;
+    const now = new Date().toISOString();
+    return {
+        id,
+        data: {
+            id,
+            userId,
+            trackId,
+            interactionType: 'vote',
+            value,
+            updatedAt: now,
+        },
+        updatedAt: now,
+    };
+}
+
+// ─── Indexed track list ───────────────────────────────────────────────────────
+
+/**
+ * Return ordered array of live (non-deleted) track documents.
+ * Used for 1-based index lookup in CLI commands.
+ *
+ * @returns {Array<{id: string, data: object, updatedAt: string}>}
+ */
+export function getTracksList() {
+    return Array.from(collections.tracks.values()).filter(d => !d.deleted);
+}
+
+// ─── Display helpers ──────────────────────────────────────────────────────────
+
+/**
+ * Return a chalk-formatted summary of the first playlist in the store.
+ * Shows track list, queue mode, turn state, and vote tallies.
+ *
+ * @returns {string}
+ */
+export function formatPlaylistDisplay() {
+    const playlists = Array.from(collections.playlists.values()).filter(d => !d.deleted);
+    if (playlists.length === 0) {
+        return chalk.yellow('No playlist data. Run "pull" to fetch from a connected peer.');
+    }
+
+    const playlist = playlists[0].data;
+    const lines = [];
+
+    lines.push(chalk.cyan(`\n🎵 Playlist: ${playlist.playlistName ?? '(unnamed)'}`));
+    lines.push(chalk.gray(`   ID:    ${playlist.id}`));
+    lines.push(chalk.gray(`   Owner: ${playlist.ownerId ?? '—'}`));
+    lines.push(chalk.gray(`   Mode:  ${playlist.queueMode ?? 'free_for_all'}`));
+    if (playlist.isCollaborative) {
+        lines.push(chalk.gray(`   Collaborative: yes`));
+    }
+
+    // Turn-taking info
+    if (playlist.queueMode === 'turn_taking') {
+        const turnUser = _resolveDisplayName(playlist.currentTurnUserId);
+        lines.push(chalk.magenta(`\n   🎲 Turn: ${turnUser}`));
+        lines.push(chalk.gray(
+            `   Progress: ${playlist.turnTracksAdded ?? 0}/${playlist.tracksPerTurn ?? 1} tracks` +
+            (playlist.maxTurns ? ` | Turn ${playlist.turnsCompleted ?? 0}/${playlist.maxTurns}` : ''),
+        ));
+        if (playlist.isComplete) {
+            lines.push(chalk.green('   ✅ Playlist marked complete'));
+        }
+    }
+
+    // Vote tallies per track
+    const voteTallies = _buildVoteTallies();
+
+    // Track list
+    const trackIds = playlist.trackIds ?? [];
+    if (trackIds.length === 0) {
+        lines.push(chalk.gray('\n   No tracks yet.'));
+    } else {
+        lines.push(chalk.bold(`\n   Tracks (${trackIds.length}):`));
+        trackIds.forEach((tid, i) => {
+            const track = collections.tracks.get(tid);
+            const label = track
+                ? `${track.data.title} — ${(track.data.artists ?? []).join(', ')}`
+                : `(unknown track ${tid.slice(0, 8)}...)`;
+            const votes = voteTallies[tid] ?? 0;
+            const voteStr = votes !== 0
+                ? (votes > 0 ? chalk.green(` [+${votes}]`) : chalk.red(` [${votes}]`))
+                : '';
+            lines.push(`   ${chalk.white(`${i + 1}.`)} ${label}${voteStr}`);
+        });
+    }
+
+    lines.push('');
+    return lines.join('\n');
+}
+
+/**
+ * Return a chalk-formatted list of all known tracks with 1-based indices.
+ *
+ * @returns {string}
+ */
+export function formatTracksDisplay() {
+    const tracks = getTracksList();
+    if (tracks.length === 0) {
+        return chalk.yellow('\nNo track data. Run "pull" to fetch from a connected peer.\n');
+    }
+
+    const lines = [chalk.cyan(`\n🎵 Tracks (${tracks.length}):\n`)];
+    tracks.forEach((doc, i) => {
+        const t = doc.data;
+        lines.push(
+            chalk.white(`  ${i + 1}. ${t.title ?? '(untitled)'}`) +
+            chalk.gray(` — ${(t.artists ?? []).join(', ')} | added by: ${(t.addedBy ?? '').slice(0, 8)}...`),
+        );
+    });
+    lines.push('');
+    return lines.join('\n');
+}
+
+/**
+ * Return a chalk-formatted summary of handshake info for all known peers.
+ *
+ * @returns {string}
+ */
+export function formatPeersInfoDisplay() {
+    if (handshakeInfoByPeer.size === 0) {
+        return chalk.yellow('\nNo handshake data yet. Connect to a peer first.\n');
+    }
+
+    const lines = [chalk.cyan(`\n🤝 Peer Handshake Info (${handshakeInfoByPeer.size}):\n`)];
+    for (const [peerId, data] of handshakeInfoByPeer.entries()) {
+        lines.push(chalk.white(`  ${data.displayName ?? '(unknown)'}`));
+        lines.push(chalk.gray(`    Peer ID:      ${peerId.slice(0, 40)}...`));
+        lines.push(chalk.gray(`    User ID:      ${(data.userId ?? '').slice(0, 8)}...`));
+        lines.push(chalk.gray(`    Version:      ${data.version ?? '—'}`));
+        lines.push(chalk.gray(`    Capabilities: ${(data.capabilities ?? []).join(', ')}`));
+        lines.push('');
+    }
+    return lines.join('\n');
+}
+
+/**
+ * Return a chalk-formatted full session state overview.
+ *
+ * @returns {string}
+ */
+export function formatSessionDisplay() {
+    const lines = [chalk.cyan('\n📊 Session State:\n')];
+
+    for (const [name, map] of Object.entries(collections)) {
+        const total = map.size;
+        const live = Array.from(map.values()).filter(d => !d.deleted).length;
+        const cp = checkpoints.get(name) ?? 'none';
+        lines.push(
+            chalk.white(`  ${name.padEnd(20)}`) +
+            chalk.gray(`${live} live / ${total} total | checkpoint: ${cp}`),
+        );
+    }
+
+    lines.push('');
+    lines.push(chalk.white('  Connected peers:  ') + chalk.gray(handshakeInfoByPeer.size));
+    for (const [peerId, data] of handshakeInfoByPeer.entries()) {
+        lines.push(chalk.gray(`    ${data.displayName ?? '?'} (${peerId.slice(0, 16)}...)`));
+    }
+
+    lines.push('');
+    return lines.join('\n');
+}
+
+// ─── Checkpoint access ────────────────────────────────────────────────────────
+
+/**
+ * Return the stored checkpoint for a collection (null if none yet).
+ * Used by the CLI pull command to request only newer documents.
+ *
+ * @param {string} collection
+ * @returns {string|null}
+ */
+export function getCheckpoint(collection) {
+    return checkpoints.get(collection) ?? null;
+}
+
+// ─── Change logging ──────────────────────────────────────────────────────────
+
+/**
+ * Log a human-readable summary of document changes after applyDocuments.
+ * Detects: track additions/removals in playlists, turn state changes,
+ * individual track upserts/deletes, and vote interactions.
+ *
+ * @param {Array} changes - the changes array from applyDocuments
+ * @param {string} collection
+ */
+export function logChangeSummary(changes, collection) {
+    const relevant = changes.filter(c => c.type !== 'skipped');
+    if (relevant.length === 0) return;
+
+    console.log(chalk.yellow(`\n[Store] ${collection}: ${relevant.length} change(s)`));
+
+    for (const change of relevant) {
+        if (change.type === 'delete') {
+            console.log(chalk.red(`  ✕ Deleted: ${change.id.slice(0, 16)}...`));
+            continue;
+        }
+
+        const data = change.incoming?.data ?? {};
+        const prev = change.previous?.data ?? null;
+
+        if (collection === 'playlists') {
+            _logPlaylistChange(data, prev);
+        } else if (collection === 'tracks') {
+            console.log(chalk.green(
+                `  + Track: ${data.title ?? '?'} — ${(data.artists ?? []).join(', ')}`,
+            ));
+        } else if (collection === 'trackInteractions') {
+            if (data.interactionType === 'vote') {
+                const sign = (data.value ?? 0) > 0 ? '+1' : '-1';
+                console.log(chalk.yellow(
+                    `  👍 Vote: ${(data.userId ?? '?').slice(0, 8)}... voted ${sign} on ${(data.trackId ?? '').slice(0, 8)}...`,
+                ));
+            }
+        } else if (collection === 'users') {
+            console.log(chalk.gray(`  👤 User: ${data.displayName ?? data.id}`));
+        }
+    }
+    console.log('');
+}
+
+// ─── Private helpers ──────────────────────────────────────────────────────────
+
+function _resolveDisplayName(userId) {
+    if (!userId) return '(nobody)';
+    const user = collections.users.get(userId);
+    return user?.data?.displayName ?? userId.slice(0, 8) + '...';
+}
+
+function _buildVoteTallies() {
+    const tallies = {};
+    for (const doc of collections.trackInteractions.values()) {
+        if (doc.deleted || doc.data?.interactionType !== 'vote') continue;
+        const { trackId, value } = doc.data;
+        if (trackId) tallies[trackId] = (tallies[trackId] ?? 0) + (value ?? 0);
+    }
+    return tallies;
+}
+
+function _logPlaylistChange(data, prev) {
+    const prevTrackIds = prev?.trackIds ?? [];
+    const newTrackIds = data.trackIds ?? [];
+
+    const added = newTrackIds.filter(id => !prevTrackIds.includes(id));
+    const removed = prevTrackIds.filter(id => !newTrackIds.includes(id));
+
+    for (const id of added) {
+        const track = collections.tracks.get(id);
+        const label = track ? `${track.data.title} — ${(track.data.artists ?? []).join(', ')}` : id.slice(0, 16);
+        console.log(chalk.green(`  + Track added to playlist: ${label}`));
+    }
+    for (const id of removed) {
+        const track = collections.tracks.get(id);
+        const label = track ? track.data.title : id.slice(0, 16);
+        console.log(chalk.red(`  - Track removed from playlist: ${label}`));
+    }
+
+    // Turn state
+    if (prev && data.currentTurnUserId !== prev.currentTurnUserId) {
+        const name = _resolveDisplayName(data.currentTurnUserId);
+        console.log(chalk.magenta(`  🎲 Turn changed to: ${name}`));
+    }
+    if (data.isComplete && !prev?.isComplete) {
+        console.log(chalk.green('  ✅ Playlist marked complete!'));
+    }
+    if (data.queueMode !== prev?.queueMode) {
+        console.log(chalk.gray(`  Mode changed to: ${data.queueMode}`));
+    }
+}


### PR DESCRIPTION
## Summary

Upgrades the test peer from a bare connection probe to a full protocol participant capable of validating playlist interactions end-to-end.

- **Protocol handlers** (`protocols.js`): JS ports of `handshake.ts` and `replication.ts`, registering both `/whatnext/handshake/1.0.0` and `/whatnext/rxdb-replication/1.0.0` with pull-response support
- **Session store** (`session-store.js`): In-memory document store with LWW conflict resolution, checkpoint tracking, document factories (track, vote), and chalk-formatted display helpers
- **CLI commands**: 7 new interactive commands (`pull`, `track-add`, `playlist`, `tracks`, `peers-info`, `vote`, `session`) with short aliases for rapid testing

## Changes

| File | Description |
|------|-------------|
| `test-peer/src/index.js` | Wire protocol modules, hoist readline to module scope, auto-initiate handshake on peer connect, add CLI commands |
| `test-peer/src/protocols.js` | Handshake and replication protocol handlers (JS ports of TS originals) |
| `test-peer/src/session-store.js` | In-memory store with LWW conflict resolution, document factories, display helpers |

## Test plan

- [ ] Start app + test peer with `node scripts/start-dev.mjs`
- [ ] Verify auto-handshake completes on peer discovery
- [ ] Test `pull` command to trigger replication pull from app
- [ ] Test `track-add` to push a track document and verify it appears in the app
- [ ] Test `vote` command and confirm vote propagation
- [ ] Verify `playlist`, `tracks`, `peers-info`, `session` display commands render correctly
- [ ] Confirm peer disconnect cleans up handshake state