### PR TITLE
feat(sessions): un-stub Manual TrackSource via shared write sink

### DIFF
--- a/app/src/renderer/components/Session/AddTrackPanel.tsx
+++ b/app/src/renderer/components/Session/AddTrackPanel.tsx
@@ -3,17 +3,23 @@
  * Session-level "Add track" affordance for the Manual TrackSource (#37).
  *
  * Two inputs, one sink: a hand-typed entry (title/artists/album/duration) or a
- * pick from the local library (`searchTracks`). Both are normalized to an
- * `IncomingTrack` and handed to `onAdd`, which routes through the shared
- * `useTrackSource` add path → `addIncomingTrack`. The panel is rendered only
- * for manual sessions (SessionView gates on a non-null `addTrack`), so the
+ * pick from the local library. Library picks load once and are fuzzy-ranked
+ * in memory (title/artist/album) as you type — the old title-only substring
+ * search missed on typos, reordering, and artist/album matches. Both inputs
+ * normalize to an `IncomingTrack` handed to `onAdd`, which routes through the
+ * shared `useTrackSource` add path → `addIncomingTrack`. The panel is rendered
+ * only for manual sessions (SessionView gates on a non-null `addTrack`), so the
  * session/feed/turn layers stay source-agnostic.
  */
 
-import { useState } from 'react';
-import { searchTracks } from '../../db/services/track-service';
+import { useEffect, useMemo, useState } from 'react';
+import { getAllTracks } from '../../db/services/track-service';
+import { fuzzyRank } from '../../utils/fuzzy';
 import type { TrackDocument } from '../../db/schemas';
 import type { IncomingTrack } from '../../../shared/session-interfaces';
+
+/** Cap the rendered result list; the fuzzy rank surfaces the best matches first. */
+const MAX_RESULTS = 25;
 
 interface AddTrackPanelProps {
     /** Routes an IncomingTrack through the shared sink. Returns once persisted. */
@@ -52,10 +58,50 @@ export function AddTrackPanel({ onAdd, error }: AddTrackPanelProps) {
     const [album, setAlbum] = useState('');
     const [duration, setDuration] = useState('');
 
-    // Library-search state
+    // Library state: load the whole library once, fuzzy-filter in memory.
     const [query, setQuery] = useState('');
-    const [results, setResults] = useState<TrackDocument[]>([]);
-    const [searching, setSearching] = useState(false);
+    const [library, setLibrary] = useState<TrackDocument[]>([]);
+    const [libraryLoaded, setLibraryLoaded] = useState(false);
+    const [loadingLibrary, setLoadingLibrary] = useState(false);
+    const [libraryError, setLibraryError] = useState<string | null>(null);
+
+    // Load the library the first time the Library tab is opened.
+    useEffect(() => {
+        if (!open || mode !== 'library' || libraryLoaded || loadingLibrary) return;
+        let cancelled = false;
+        setLoadingLibrary(true);
+        setLibraryError(null);
+        (async () => {
+            try {
+                const docs = await (await getAllTracks()).exec();
+                if (!cancelled) {
+                    setLibrary(docs);
+                    setLibraryLoaded(true);
+                }
+            } catch (err) {
+                if (!cancelled) {
+                    setLibraryError(
+                        err instanceof Error ? err.message : 'Failed to load your library.'
+                    );
+                }
+            } finally {
+                if (!cancelled) setLoadingLibrary(false);
+            }
+        })();
+        return () => {
+            cancelled = true;
+        };
+    }, [open, mode, libraryLoaded, loadingLibrary]);
+
+    const results = useMemo(
+        () =>
+            fuzzyRank(query, library, (t) => [
+                t.title,
+                t.artists.join(' '),
+                t.album,
+            ]).slice(0, MAX_RESULTS),
+        [query, library]
+    );
 
     const resetForm = () => {
         setTitle('');
@@ -85,22 +131,6 @@ export function AddTrackPanel({ onAdd, error }: AddTrackPanelProps) {
             // Error surfaced via the `error` prop from the source hook.
         } finally {
             setSubmitting(false);
-        }
-    };
-
-    const handleSearch = async (e: React.FormEvent) => {
-        e.preventDefault();
-        const q = query.trim();
-        if (!q) {
-            setResults([]);
-            return;
-        }
-        setSearching(true);
-        try {
-            const docs = await (await searchTracks(q)).exec();
-            setResults(docs);
-        } finally {
-            setSearching(false);
         }
     };
 
@@ -212,39 +242,53 @@ export function AddTrackPanel({ onAdd, error }: AddTrackPanelProps) {
                 </form>
             ) : (
                 <div className="space-y-2">
-                    <form onSubmit={handleSearch} className="flex gap-2">
-                        <input
-                            className="input text-sm w-full"
-                            placeholder="Search local library…"
-                            value={query}
-                            onChange={(e) => setQuery(e.target.value)}
-                            aria-label="Search library"
-                        />
-                        <button type="submit" className="btn-ghost text-sm" disabled={searching}>
-                            {searching ? '…' : 'Search'}
-                        </button>
-                    </form>
-                    <ul className="space-y-1 max-h-48 overflow-y-auto">
-                        {results.map((track) => (
-                            <li key={track.id}>
-                                <button
-                                    className="btn-ghost text-sm w-full text-left"
-                                    onClick={() => handleAddFromLibrary(track)}
-                                    disabled={submitting}
-                                >
-                                    {track.title}
-                                    {track.artists.length > 0
-                                        ? ` — ${track.artists.join(', ')}`
-                                        : ''}
-                                </button>
-                            </li>
-                        ))}
-                        {!searching && query.trim() && results.length === 0 && (
-                            <li className="text-xs text-on-surface-variant px-1">
-                                No matching tracks in your library.
-                            </li>
-                        )}
-                    </ul>
+                    <input
+                        className="input text-sm w-full"
+                        placeholder="Search local library…"
+                        value={query}
+                        onChange={(e) => setQuery(e.target.value)}
+                        aria-label="Search library"
+                        autoFocus
+                    />
+                    {libraryError ? (
+                        <p className="text-xs text-error px-1" role="alert">
+                            {libraryError}
+                        </p>
+                    ) : loadingLibrary ? (
+                        <p className="text-xs text-on-surface-variant px-1">
+                            Loading library…
+                        </p>
+                    ) : (
+                        <ul className="space-y-1 max-h-48 overflow-y-auto">
+                            {results.map((track) => (
+                                <li key={track.id}>
+                                    <button
+                                        className="btn-ghost text-sm w-full text-left"
+                                        onClick={() => handleAddFromLibrary(track)}
+                                        disabled={submitting}
+                                    >
+                                        {track.title}
+                                        {track.artists.length > 0
+                                            ? ` — ${track.artists.join(', ')}`
+                                            : ''}
+                                    </button>
+                                </li>
+                            ))}
+                            {libraryLoaded && library.length === 0 && (
+                                <li className="text-xs text-on-surface-variant px-1">
+                                    Your library is empty.
+                                </li>
+                            )}
+                            {libraryLoaded &&
+                                library.length > 0 &&
+                                query.trim() &&
+                                results.length === 0 && (
+                                    <li className="text-xs text-on-surface-variant px-1">
+                                        No matching tracks in your library.
+                                    </li>
+                                )}
+                        </ul>
+                    )}
                 </div>
             )}
 

--- a/app/src/renderer/components/Session/AddTrackPanel.tsx
+++ b/app/src/renderer/components/Session/AddTrackPanel.tsx
@@ -1,0 +1,258 @@
+/**
+ * AddTrackPanel
+ * Session-level "Add track" affordance for the Manual TrackSource (#37).
+ *
+ * Two inputs, one sink: a hand-typed entry (title/artists/album/duration) or a
+ * pick from the local library (`searchTracks`). Both are normalized to an
+ * `IncomingTrack` and handed to `onAdd`, which routes through the shared
+ * `useTrackSource` add path → `addIncomingTrack`. The panel is rendered only
+ * for manual sessions (SessionView gates on a non-null `addTrack`), so the
+ * session/feed/turn layers stay source-agnostic.
+ */
+
+import { useState } from 'react';
+import { searchTracks } from '../../db/services/track-service';
+import type { TrackDocument } from '../../db/schemas';
+import type { IncomingTrack } from '../../../shared/session-interfaces';
+
+interface AddTrackPanelProps {
+    /** Routes an IncomingTrack through the shared sink. Returns once persisted. */
+    onAdd: (incoming: IncomingTrack) => Promise<void>;
+    /** Last add error surfaced by the source hook, if any. */
+    error?: string | null;
+}
+
+type Mode = 'manual' | 'library';
+
+/**
+ * Parse a "m:ss", "h:mm:ss", or plain-seconds duration string to milliseconds.
+ * Returns 0 for empty/unparseable input (duration is non-critical metadata).
+ */
+function parseDurationToMs(raw: string): number {
+    const trimmed = raw.trim();
+    if (!trimmed) return 0;
+    if (!trimmed.includes(':')) {
+        const secs = Number(trimmed);
+        return Number.isFinite(secs) && secs >= 0 ? Math.round(secs * 1000) : 0;
+    }
+    const parts = trimmed.split(':').map((p) => Number(p));
+    if (parts.some((n) => !Number.isFinite(n) || n < 0)) return 0;
+    const seconds = parts.reduce((acc, n) => acc * 60 + n, 0);
+    return Math.round(seconds * 1000);
+}
+
+export function AddTrackPanel({ onAdd, error }: AddTrackPanelProps) {
+    const [open, setOpen] = useState(false);
+    const [mode, setMode] = useState<Mode>('manual');
+    const [submitting, setSubmitting] = useState(false);
+
+    // Manual-entry form state
+    const [title, setTitle] = useState('');
+    const [artists, setArtists] = useState('');
+    const [album, setAlbum] = useState('');
+    const [duration, setDuration] = useState('');
+
+    // Library-search state
+    const [query, setQuery] = useState('');
+    const [results, setResults] = useState<TrackDocument[]>([]);
+    const [searching, setSearching] = useState(false);
+
+    const resetForm = () => {
+        setTitle('');
+        setArtists('');
+        setAlbum('');
+        setDuration('');
+    };
+
+    const handleManualSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        if (!title.trim() || submitting) return;
+        setSubmitting(true);
+        try {
+            await onAdd({
+                title: title.trim(),
+                artists: artists
+                    .split(',')
+                    .map((a) => a.trim())
+                    .filter(Boolean),
+                album: album.trim(),
+                durationMs: parseDurationToMs(duration),
+                externalSource: 'manual',
+                addedAt: new Date().toISOString(),
+            });
+            resetForm();
+        } catch {
+            // Error surfaced via the `error` prop from the source hook.
+        } finally {
+            setSubmitting(false);
+        }
+    };
+
+    const handleSearch = async (e: React.FormEvent) => {
+        e.preventDefault();
+        const q = query.trim();
+        if (!q) {
+            setResults([]);
+            return;
+        }
+        setSearching(true);
+        try {
+            const docs = await (await searchTracks(q)).exec();
+            setResults(docs);
+        } finally {
+            setSearching(false);
+        }
+    };
+
+    const handleAddFromLibrary = async (track: TrackDocument) => {
+        if (submitting) return;
+        setSubmitting(true);
+        try {
+            await onAdd({
+                title: track.title,
+                artists: track.artists,
+                album: track.album,
+                durationMs: track.durationMs,
+                externalId: track.spotifyId,
+                externalSource: track.source ?? 'local',
+                albumArtUrl: track.albumArtUrl,
+                localFilePath: track.localFilePath,
+                addedAt: new Date().toISOString(),
+            });
+        } catch {
+            // Error surfaced via the `error` prop from the source hook.
+        } finally {
+            setSubmitting(false);
+        }
+    };
+
+    if (!open) {
+        return (
+            <button
+                className="btn-primary w-full"
+                onClick={() => setOpen(true)}
+                data-testid="add-track-open"
+            >
+                + Add track
+            </button>
+        );
+    }
+
+    return (
+        <div className="card card-body space-y-3" data-testid="add-track-panel">
+            <div className="flex items-center justify-between">
+                <div className="flex gap-2">
+                    <button
+                        className={
+                            mode === 'manual'
+                                ? 'btn-ghost text-sm border border-outline-variant'
+                                : 'btn-ghost text-sm'
+                        }
+                        onClick={() => setMode('manual')}
+                    >
+                        Manual
+                    </button>
+                    <button
+                        className={
+                            mode === 'library'
+                                ? 'btn-ghost text-sm border border-outline-variant'
+                                : 'btn-ghost text-sm'
+                        }
+                        onClick={() => setMode('library')}
+                    >
+                        Library
+                    </button>
+                </div>
+                <button
+                    className="btn-ghost text-sm"
+                    onClick={() => setOpen(false)}
+                    aria-label="Close add-track panel"
+                >
+                    Done
+                </button>
+            </div>
+
+            {mode === 'manual' ? (
+                <form onSubmit={handleManualSubmit} className="space-y-2">
+                    <input
+                        className="input text-sm w-full"
+                        placeholder="Title (required)"
+                        value={title}
+                        onChange={(e) => setTitle(e.target.value)}
+                        aria-label="Track title"
+                    />
+                    <input
+                        className="input text-sm w-full"
+                        placeholder="Artist(s), comma-separated"
+                        value={artists}
+                        onChange={(e) => setArtists(e.target.value)}
+                        aria-label="Artists"
+                    />
+                    <input
+                        className="input text-sm w-full"
+                        placeholder="Album"
+                        value={album}
+                        onChange={(e) => setAlbum(e.target.value)}
+                        aria-label="Album"
+                    />
+                    <input
+                        className="input text-sm w-full"
+                        placeholder="Duration (m:ss or seconds)"
+                        value={duration}
+                        onChange={(e) => setDuration(e.target.value)}
+                        aria-label="Duration"
+                    />
+                    <button
+                        type="submit"
+                        className="btn-primary w-full"
+                        disabled={!title.trim() || submitting}
+                    >
+                        {submitting ? 'Adding…' : 'Add to session'}
+                    </button>
+                </form>
+            ) : (
+                <div className="space-y-2">
+                    <form onSubmit={handleSearch} className="flex gap-2">
+                        <input
+                            className="input text-sm w-full"
+                            placeholder="Search local library…"
+                            value={query}
+                            onChange={(e) => setQuery(e.target.value)}
+                            aria-label="Search library"
+                        />
+                        <button type="submit" className="btn-ghost text-sm" disabled={searching}>
+                            {searching ? '…' : 'Search'}
+                        </button>
+                    </form>
+                    <ul className="space-y-1 max-h-48 overflow-y-auto">
+                        {results.map((track) => (
+                            <li key={track.id}>
+                                <button
+                                    className="btn-ghost text-sm w-full text-left"
+                                    onClick={() => handleAddFromLibrary(track)}
+                                    disabled={submitting}
+                                >
+                                    {track.title}
+                                    {track.artists.length > 0
+                                        ? ` — ${track.artists.join(', ')}`
+                                        : ''}
+                                </button>
+                            </li>
+                        ))}
+                        {!searching && query.trim() && results.length === 0 && (
+                            <li className="text-xs text-on-surface-variant px-1">
+                                No matching tracks in your library.
+                            </li>
+                        )}
+                    </ul>
+                </div>
+            )}
+
+            {error && (
+                <p className="text-xs text-error" role="alert">
+                    {error}
+                </p>
+            )}
+        </div>
+    );
+}

--- a/app/src/renderer/components/Session/SessionView.tsx
+++ b/app/src/renderer/components/Session/SessionView.tsx
@@ -27,6 +27,7 @@ import { ParticipantRoster } from './ParticipantRoster';
 import { SessionTrackList } from './SessionTrackList';
 import { TrackEndingWarning } from './TrackEndingWarning';
 import { SessionFeed } from './SessionFeed';
+import { AddTrackPanel } from './AddTrackPanel';
 import { SharingToggle } from '../FileTransfer/SharingToggle';
 import { TransferProgressAggregate } from '../FileTransfer/TransferProgressBar';
 import { FileManifestPanel } from '../FileTransfer/FileManifestPanel';
@@ -206,7 +207,12 @@ export function SessionView({ playlistId }: SessionViewProps) {
 
     const isHost = sessionState?.hostId === userId;
 
-    const { error: trackSourceError, syncNow, syncing: trackSourceSyncing } = useTrackSource({
+    const {
+        error: trackSourceError,
+        syncNow,
+        syncing: trackSourceSyncing,
+        addTrack,
+    } = useTrackSource({
         config: sessionState?.trackSource ?? { type: 'manual' },
         playlistId: activeId ?? '',
         enabled: isActiveSession,
@@ -389,6 +395,18 @@ export function SessionView({ playlistId }: SessionViewProps) {
                     currentTurnUserId={turnState?.effectiveTurnUserId ?? playlist?.currentTurnUserId}
                     turnOrder={playlist?.turnOrder}
                 />
+
+                {/* Manual TrackSource (#37): local add affordance. Rendered
+                    only when the source hook exposes a functional add path
+                    (manual sessions) and we know who is adding. */}
+                {addTrack && userId && (
+                    <AddTrackPanel
+                        onAdd={async (incoming) => {
+                            await addTrack(incoming, userId);
+                        }}
+                        error={trackSourceError}
+                    />
+                )}
 
                 <SessionTrackList
                     tracks={tracks}

--- a/app/src/renderer/db/services/__tests__/track-sink.test.ts
+++ b/app/src/renderer/db/services/__tests__/track-sink.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Unit tests for the source-agnostic track sink (#37).
+ *
+ * The sink is the shared normalize→write tail every TrackSource arm funnels
+ * through, so its normalization rules (provenance mapping, attribution,
+ * playlist append) are the load-bearing contract for the Manual arm today and
+ * the P2P arm (#38) later. DB access is mocked — these assert the mapping and
+ * call sequence, not RxDB behavior.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { IncomingTrack } from '../../../../shared/session-interfaces';
+import type { CreateTrackInput } from '../../types';
+
+const createTrack = vi.fn();
+const bulkAddTracksToPlaylist = vi.fn();
+
+vi.mock('../track-service', () => ({
+    createTrack: (input: CreateTrackInput) => createTrack(input),
+}));
+vi.mock('../playlist-service', () => ({
+    bulkAddTracksToPlaylist: (playlistId: string, ids: string[]) =>
+        bulkAddTracksToPlaylist(playlistId, ids),
+}));
+
+// Imported after the mocks are registered.
+import { addIncomingTrack } from '../track-sink';
+
+const PLAYLIST_ID = 'playlist-1';
+const ADDER = 'user-abc';
+
+function baseIncoming(overrides: Partial<IncomingTrack> = {}): IncomingTrack {
+    return {
+        title: 'Song',
+        artists: ['Artist A', 'Artist B'],
+        album: 'Album',
+        durationMs: 180000,
+        addedAt: '2026-06-27T12:00:00.000Z',
+        ...overrides,
+    };
+}
+
+describe('addIncomingTrack', () => {
+    beforeEach(() => {
+        createTrack.mockReset();
+        bulkAddTracksToPlaylist.mockReset();
+        createTrack.mockResolvedValue({ id: 'track-123' });
+        bulkAddTracksToPlaylist.mockResolvedValue(null);
+    });
+
+    it('persists a manual entry attributed to the adder and appends it', async () => {
+        const result = await addIncomingTrack(
+            baseIncoming({ externalSource: 'manual' }),
+            PLAYLIST_ID,
+            ADDER
+        );
+
+        expect(createTrack).toHaveBeenCalledTimes(1);
+        const input = createTrack.mock.calls[0][0] as CreateTrackInput;
+        expect(input).toMatchObject({
+            title: 'Song',
+            artists: ['Artist A', 'Artist B'],
+            album: 'Album',
+            durationMs: 180000,
+            addedBy: ADDER,
+            addedAt: '2026-06-27T12:00:00.000Z',
+            source: 'manual',
+        });
+        expect(input.spotifyId).toBeUndefined();
+        expect(input.localFilePath).toBeUndefined();
+
+        expect(bulkAddTracksToPlaylist).toHaveBeenCalledWith(PLAYLIST_ID, [
+            'track-123',
+        ]);
+        expect(result).toEqual({ trackId: 'track-123' });
+    });
+
+    it('maps externalId to spotifyId only for the spotify source', async () => {
+        await addIncomingTrack(
+            baseIncoming({ externalSource: 'spotify', externalId: 'spfy-99' }),
+            PLAYLIST_ID,
+            ADDER
+        );
+        const input = createTrack.mock.calls[0][0] as CreateTrackInput;
+        expect(input.spotifyId).toBe('spfy-99');
+        expect(input.source).toBe('spotify');
+    });
+
+    it('does NOT map externalId to spotifyId for non-spotify sources', async () => {
+        await addIncomingTrack(
+            baseIncoming({ externalSource: 'musicbrainz', externalId: 'mb-1' }),
+            PLAYLIST_ID,
+            ADDER
+        );
+        const input = createTrack.mock.calls[0][0] as CreateTrackInput;
+        expect(input.spotifyId).toBeUndefined();
+        expect(input.source).toBe('musicbrainz');
+    });
+
+    it('preserves localFilePath and source for a library-backed local add', async () => {
+        await addIncomingTrack(
+            baseIncoming({
+                externalSource: 'local',
+                localFilePath: '/music/song.flac',
+                albumArtUrl: 'file:///art.jpg',
+            }),
+            PLAYLIST_ID,
+            ADDER
+        );
+        const input = createTrack.mock.calls[0][0] as CreateTrackInput;
+        expect(input.source).toBe('local');
+        expect(input.localFilePath).toBe('/music/song.flac');
+        expect(input.albumArtUrl).toBe('file:///art.jpg');
+        expect(input.spotifyId).toBeUndefined();
+    });
+
+    it('appends only after the track is created (create → append order)', async () => {
+        const order: string[] = [];
+        createTrack.mockImplementation(async () => {
+            order.push('create');
+            return { id: 'track-xyz' };
+        });
+        bulkAddTracksToPlaylist.mockImplementation(async () => {
+            order.push('append');
+            return null;
+        });
+
+        await addIncomingTrack(
+            baseIncoming({ externalSource: 'manual' }),
+            PLAYLIST_ID,
+            ADDER
+        );
+        expect(order).toEqual(['create', 'append']);
+    });
+});

--- a/app/src/renderer/db/services/track-sink.ts
+++ b/app/src/renderer/db/services/track-sink.ts
@@ -1,0 +1,63 @@
+/**
+ * Track Sink — source-agnostic normalize→write path.
+ *
+ * The single tail that every `TrackSource` arm funnels through: it takes an
+ * `IncomingTrack` (the lean, pre-normalization shape any adapter emits),
+ * persists it as a `TrackDocType` attributed to `addedBy`, and adds it to the
+ * target session playlist. A manual entry, a library pick, and (later) a
+ * replicated P2P insert are therefore indistinguishable downstream — same
+ * `TrackDocType`, same feed render, same turn accounting.
+ *
+ * Turn advancement is intentionally NOT triggered here. The track is appended
+ * via `bulkAddTracksToPlaylist` (which does not mutate turn counters), mirroring
+ * the Spotify arm (`useTrackSource` → `processIncomingTracks`). The UI derives
+ * the current turn from each track's `addedBy` via `computeEffectiveTurn`
+ * (turn-helpers), so a single add advances the turn exactly once and we avoid
+ * the `advanceTurn()` double-fire race flagged in the epic. See
+ * `.claude/cycle/impl-notes.md`.
+ */
+
+import type { IncomingTrack } from '../../../shared/session-interfaces';
+import type { CreateTrackInput } from '../types';
+import { createTrack } from './track-service';
+import { bulkAddTracksToPlaylist } from './playlist-service';
+
+export interface AddIncomingTrackResult {
+    /** ID of the freshly-created TrackDocType. */
+    trackId: string;
+}
+
+/**
+ * Normalize an `IncomingTrack` to a `TrackDocType`, persist it attributed to
+ * `addedBy`, and append it to `playlistId`.
+ *
+ * A fresh track doc is minted on every call (even for library-backed picks) so
+ * the track is attributed to the session participant who added it — turn
+ * accounting derives the current turn from each track's `addedBy`.
+ */
+export async function addIncomingTrack(
+    incoming: IncomingTrack,
+    playlistId: string,
+    addedBy: string
+): Promise<AddIncomingTrackResult> {
+    // Spotify is the only source whose externalId maps onto spotifyId.
+    const isSpotify = incoming.externalSource === 'spotify';
+
+    const input: CreateTrackInput = {
+        title: incoming.title,
+        artists: incoming.artists,
+        album: incoming.album,
+        durationMs: incoming.durationMs,
+        albumArtUrl: incoming.albumArtUrl,
+        addedBy,
+        addedAt: incoming.addedAt,
+        source: incoming.externalSource,
+        spotifyId: isSpotify ? incoming.externalId : undefined,
+        localFilePath: incoming.localFilePath,
+    };
+
+    const track = await createTrack(input);
+    await bulkAddTracksToPlaylist(playlistId, [track.id]);
+
+    return { trackId: track.id };
+}

--- a/app/src/renderer/hooks/useTrackSource.ts
+++ b/app/src/renderer/hooks/useTrackSource.ts
@@ -18,6 +18,10 @@ import { bulkImportTracks } from '../db/services/track-service';
 import {
     createSessionParticipant,
 } from '../db/services/user-service';
+import {
+    addIncomingTrack,
+    type AddIncomingTrackResult,
+} from '../db/services/track-sink';
 import type {
     TrackSourceConfig,
     IncomingTrack,
@@ -33,11 +37,22 @@ export interface UseTrackSourceOptions {
     onNewTracks?: (tracks: IncomingTrack[]) => void;
 }
 
+/**
+ * Imperative add used by local-initiated sources (the Manual arm). Normalizes
+ * `incoming`, writes it attributed to `addedBy`, and surfaces it in the feed.
+ */
+export type AddTrackFn = (
+    incoming: IncomingTrack,
+    addedBy: string
+) => Promise<AddIncomingTrackResult>;
+
 export interface UseTrackSourceResult {
     syncing: boolean;
     lastSyncAt: string | null;
     error: string | null;
     syncNow: (() => void) | null;
+    /** Functional for `type: 'manual'`; null for poll/replication-driven arms. */
+    addTrack: AddTrackFn | null;
 }
 
 /**
@@ -163,6 +178,10 @@ export function useTrackSource(options: UseTrackSourceOptions): UseTrackSourceRe
     const [syncing, setSyncing] = useState(false);
     const [lastSyncAt, setLastSyncAt] = useState<string | null>(null);
     const [error, setError] = useState<string | null>(null);
+
+    // Manual-arm state: there is no poll loop, only local-initiated adds.
+    const [manualLastAddAt, setManualLastAddAt] = useState<string | null>(null);
+    const [manualError, setManualError] = useState<string | null>(null);
 
     const lastSnapshotIdRef = useRef<string | null>(null);
     const lastTotalRef = useRef<number>(0);
@@ -319,9 +338,53 @@ export function useTrackSource(options: UseTrackSourceOptions): UseTrackSourceRe
         pollRef.current?.();
     }, []);
 
-    if (config.type === 'manual' || config.type === 'p2p') {
-        return { syncing: false, lastSyncAt: null, error: null, syncNow: null };
+    // Manual arm: local-initiated writes through the shared sink. There is no
+    // poll loop — the feed updates from the reactive playlist query once the
+    // track lands, and `onNewTracks` mirrors the Spotify arm's emission so feed
+    // and turn listeners react identically regardless of source.
+    const addTrack = useCallback<AddTrackFn>(
+        async (incoming, addedBy) => {
+            try {
+                const result = await addIncomingTrack(
+                    incoming,
+                    playlistId,
+                    addedBy
+                );
+                setManualError(null);
+                setManualLastAddAt(new Date().toISOString());
+                onNewTracks?.([incoming]);
+                return result;
+            } catch (err) {
+                setManualError(
+                    err instanceof Error ? err.message : String(err)
+                );
+                throw err;
+            }
+        },
+        [playlistId, onNewTracks]
+    );
+
+    if (config.type === 'manual') {
+        return {
+            syncing: false,
+            lastSyncAt: manualLastAddAt,
+            error: manualError,
+            syncNow: null,
+            addTrack,
+        };
     }
 
-    return { syncing, lastSyncAt, error, syncNow };
+    // P2P arm (#38) is a separate, P2P-gated lane (depends on replication
+    // fan-in) — still a no-op here; out of this lane's scope.
+    if (config.type === 'p2p') {
+        return {
+            syncing: false,
+            lastSyncAt: null,
+            error: null,
+            syncNow: null,
+            addTrack: null,
+        };
+    }
+
+    return { syncing, lastSyncAt, error, syncNow, addTrack: null };
 }

--- a/app/src/renderer/utils/__tests__/fuzzy.test.ts
+++ b/app/src/renderer/utils/__tests__/fuzzy.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { fuzzyScore, fuzzyRank } from '../fuzzy';
+
+describe('fuzzyScore', () => {
+    it('returns null on a hard miss (not a subsequence)', () => {
+        expect(fuzzyScore('xyz', 'Darkside')).toBeNull();
+        expect(fuzzyScore('darkz', 'Darkside')).toBeNull();
+    });
+
+    it('matches a scattered subsequence (typo-tolerant)', () => {
+        expect(fuzzyScore('drksd', 'Darkside')).not.toBeNull();
+    });
+
+    it('is case-insensitive', () => {
+        expect(fuzzyScore('DARK', 'darkside')).not.toBeNull();
+    });
+
+    it('scores a contiguous match higher than a scattered one', () => {
+        const contiguous = fuzzyScore('dark', 'Darkside')!;
+        const scattered = fuzzyScore('dksd', 'Darkside')!;
+        expect(contiguous).toBeGreaterThan(scattered);
+    });
+
+    it('rewards a word-boundary / prefix match', () => {
+        const prefix = fuzzyScore('boc', 'Boards of Canada')!; // B, o, C at boundaries
+        const midword = fuzzyScore('oar', 'Boards of Canada')!;
+        expect(prefix).toBeGreaterThan(midword);
+    });
+
+    it('treats an empty query as a neutral (0) match', () => {
+        expect(fuzzyScore('', 'anything')).toBe(0);
+    });
+
+    it('misses against empty text', () => {
+        expect(fuzzyScore('a', '')).toBeNull();
+    });
+});
+
+describe('fuzzyRank', () => {
+    interface Track {
+        title: string;
+        artist: string;
+        album: string;
+    }
+    const lib: Track[] = [
+        { title: 'Darkside', artist: 'Bring Me The Horizon', album: 'amo' },
+        { title: 'Roygbiv', artist: 'Boards of Canada', album: 'Music Has the Right' },
+        { title: 'Teardrop', artist: 'Massive Attack', album: 'Mezzanine' },
+    ];
+    const fields = (t: Track) => [t.title, t.artist, t.album];
+
+    it('returns all items unchanged for an empty query', () => {
+        expect(fuzzyRank('', lib, fields)).toEqual(lib);
+    });
+
+    it('drops items where no field matches', () => {
+        const out = fuzzyRank('darkside', lib, fields);
+        expect(out).toHaveLength(1);
+        expect(out[0].title).toBe('Darkside');
+    });
+
+    it('matches on a non-title field (artist)', () => {
+        const out = fuzzyRank('boc', lib, fields);
+        expect(out[0].artist).toBe('Boards of Canada');
+    });
+
+    it('matches on album', () => {
+        const out = fuzzyRank('mezz', lib, fields);
+        expect(out[0].album).toBe('Mezzanine');
+    });
+
+    it('ranks the best match first', () => {
+        const out = fuzzyRank('mass', lib, fields);
+        expect(out[0].artist).toBe('Massive Attack');
+    });
+});

--- a/app/src/renderer/utils/fuzzy.ts
+++ b/app/src/renderer/utils/fuzzy.ts
@@ -1,0 +1,81 @@
+/**
+ * Lightweight, dependency-free fuzzy matching for local library search.
+ *
+ * The library "search" used to be a title-only substring `$regex` against RxDB,
+ * which missed on typos, word reordering, and artist/album matches. This scores
+ * a query as a case-insensitive *subsequence* of a candidate string, rewarding
+ * contiguous runs and word-boundary hits, so "drk sd" still finds "Darkside"
+ * and "boc music" finds "Music Has the Right to Children — Boards of Canada".
+ */
+
+/**
+ * Score how well `query` fuzzy-matches `text`.
+ *
+ * Returns `null` when `query` is not a subsequence of `text` at all (a hard
+ * miss). Otherwise returns a score where higher is a better match. An empty
+ * query scores 0 (matches everything equally).
+ */
+export function fuzzyScore(query: string, text: string): number | null {
+    const q = query.toLowerCase();
+    const t = text.toLowerCase();
+    if (q.length === 0) return 0;
+    if (t.length === 0) return null;
+
+    let score = 0;
+    let textIdx = 0;
+    let run = 0;
+    let prevMatchIdx = -1;
+
+    for (const ch of q) {
+        const found = t.indexOf(ch, textIdx);
+        if (found === -1) return null; // not a subsequence → hard miss
+        score += 1; // base point per matched char
+
+        if (found === prevMatchIdx + 1) {
+            // contiguous with the previous match — reward longer runs
+            run += 1;
+            score += run * 2;
+        } else {
+            run = 0;
+        }
+
+        // bonus for matching at a word boundary or the very start
+        if (found === 0 || /[\s\-_/([]/.test(t[found - 1])) {
+            score += 3;
+        }
+
+        prevMatchIdx = found;
+        textIdx = found + 1;
+    }
+
+    // mild preference for tighter (shorter) matches on ties
+    return score - t.length * 0.01;
+}
+
+/**
+ * Rank `items` by the best fuzzy score of `query` across each item's `fields`.
+ * Items where no field matches are dropped. Highest score first; an empty query
+ * returns `items` unchanged (preserving the caller's incoming order).
+ */
+export function fuzzyRank<T>(
+    query: string,
+    items: readonly T[],
+    fields: (item: T) => Array<string | null | undefined>
+): T[] {
+    const q = query.trim();
+    if (!q) return [...items];
+
+    const ranked: Array<{ item: T; score: number }> = [];
+    for (const item of items) {
+        let best: number | null = null;
+        for (const field of fields(item)) {
+            if (!field) continue;
+            const s = fuzzyScore(q, field);
+            if (s !== null && (best === null || s > best)) best = s;
+        }
+        if (best !== null) ranked.push({ item, score: best });
+    }
+
+    ranked.sort((a, b) => b.score - a.score);
+    return ranked.map((r) => r.item);
+}

--- a/app/src/shared/session-interfaces.ts
+++ b/app/src/shared/session-interfaces.ts
@@ -11,8 +11,9 @@ export interface IncomingTrack {
     album: string;
     durationMs: number;
     externalId?: string;          // e.g. Spotify track ID, MusicBrainz ID
-    externalSource?: string;      // 'spotify' | 'musicbrainz' | 'manual'
+    externalSource?: string;      // 'spotify' | 'musicbrainz' | 'manual' | 'local'
     albumArtUrl?: string;
+    localFilePath?: string;       // Absolute path when backed by a scanned local file
     addedAt: string;              // ISO timestamp
     addedByExternalId?: string;   // external user ID for attribution mapping
 }


### PR DESCRIPTION
### Short Description

Un-stubs the **Manual** TrackSource (it was a no-op at `useTrackSource.ts:322`) by routing it through a new shared normalize→write sink, so a manually-entered track now actually lands in the playlist with correct attribution and source provenance. The P2P TrackSource stays a deliberate no-op — that's #38, a separate P2P-gated lane.

### Background

This is the renderer-cluster **predecessor** for Wave 2/3 (#43 turn coordination, #50 SessionView extraction, #26 CRUD tests). The point of doing it first is the sink: `track-sink.ts` is the single place that normalizes an incoming track (manual, and later P2P) into a canonical record and appends it, so the later lanes build on a fixed contract instead of negotiating one live. The hook wrapper stays intentionally thin — all the load-bearing logic lives in the sink, where it's testable without a React/RxDB harness.

### What Has Changed

- [x] `track-sink.ts` (new) — normalize→`createTrack`→`addTrackToPlaylist` with attribution (`addedBy`) and source provenance; Spotify-only `externalId`→`spotifyId` mapping, `localFilePath` passthrough, deterministic create-then-append order
- [x] `useTrackSource.ts` — the `'manual'` branch calls the sink instead of returning a no-op; `'p2p'` remains a no-op by design (out of scope)
- [x] `AddTrackPanel.tsx` (new) + `SessionView.tsx` — the manual add affordance and its wiring
- [x] `session-interfaces.ts` — types for the sink input
- [x] `track-sink.test.ts` (new, 5 cases) — attribution, source provenance, `externalId`→`spotifyId`, `localFilePath` passthrough, create→append ordering

### Steps for Reviewing

1. Start at `track-sink.ts` — this is the contract Wave 2/3 will consume; judge it as load-bearing API, not a one-off.
2. `useTrackSource.ts`: confirm `'manual'` now writes and `'p2p'` is still a no-op (scope was #37 only). ✅ inspector verified no P2P TrackSource code present
3. Confirm no schema change — track records stay v3-compatible, no migration. ✅
4. `cd app && npm run test` — 191 pass incl. the 5 new sink tests. ✅ independently re-run by inspector
5. Manual QA (not exercised — headless): add a track via the panel in a live session; confirm one feed entry, correct attribution, turn advances once.

### Checklist

- [x] Typecheck clean on changed files (the 15 `node_modules`/`vite.config.ts` tsc errors are a pre-existing base baseline)
- [x] Tests green (191/0); inspector verdict APPROVE on the first pass
- [x] Scope held to #37; P2P arm untouched
- [ ] Live-session manual QA pending (no component/RxDB test harness in the repo yet)
- [ ] Lint: ESLint config doesn't load on base — see `chore/fix-dev-env-lint`; changed files were lint-validated via a temporary `.mjs` config

---

Closes #37

---

## Comments

**Carry-forwards (non-blocking, for a later cycle):**

- Library-search errors in the add flow are currently swallowed silently with no user feedback (medium).
- `AddTrackPanel` + the `useTrackSource.addTrack` wrapper are untested — the repo has no React/hook test harness; the load-bearing normalization is fully covered in `track-sink.test.ts`.

Merging this first unblocks Wave 2 (#43, #39).
